### PR TITLE
Add 0001-Python-3.10-compat.patch

### DIFF
--- a/recipe/0001-Python-3.10-compat.patch
+++ b/recipe/0001-Python-3.10-compat.patch
@@ -1,0 +1,13 @@
+diff --git a/peppy/project.py b/peppy/project.py
+index e1f187d..3e27b38 100644
+--- a/peppy/project.py
++++ b/peppy/project.py
+@@ -2,7 +2,7 @@
+ Build a Project object.
+ """
+ import os
+-from collections import Mapping
++from collections.abc import Mapping
+ from logging import getLogger
+ 
+ import pandas as pd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,12 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 2f8b19ca3e034afea77aa11d2b8d30982adc4b0ce44bae6d8ecd5cf0da0af002
+  patches:
+    # Can be removed once 0.32 is out.
+    - 0001-Python-3.10-compat.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Alternative to/resolves gh-8.
<!--
Please add any other relevant info below:
-->
The patch can be removed once 0.32 is out.